### PR TITLE
use klass to get association class

### DIFF
--- a/lib/eager_group/preloader.rb
+++ b/lib/eager_group/preloader.rb
@@ -14,7 +14,7 @@ module EagerGroup
         definition = @klass.eager_group_definations[eager_group_value]
         if definition
           reflection = @klass.reflect_on_association(definition.association)
-          association_class = reflection.class_name.constantize
+          association_class = reflection.klass
           association_class = association_class.instance_exec(&definition.scope) if definition.scope
           polymophic_as_condition = lambda {|reflection|
             if reflection.type


### PR DESCRIPTION
My application has multiple databases and I configure them under different namespaces.
```
Cba::Db1::Users
Cba::Db2::Users
```
These models share same methods and include modules like below

```
module Cba
  module Rates
    extend ActiveSupport::Concern
    included do
      self.table_name = 'Rates'
      has_many :Rate_Comparisons, :class_name => RateComparisons, :foreign_key => "RateID"
      define_eager_group :comparison_count, :Rate_Comparisons, :count, :*

    end
  end
end
```

When I run `eager_group(:comparison_count)` it will raise error `underfined method where on Cba::Rate_Comparisons`

After I debug, I find the class_name in association object is not correct.
```
preloader.rb

association.class_name # => Cba::RateComparisons, not the real class, cause issues
```
but the instance variables `@klass` is correct. so, change to use klass to get association class

