### PR TITLE
Bugfix: Add STI support, validations

### DIFF
--- a/lib/active_record/with_eager_group.rb
+++ b/lib/active_record/with_eager_group.rb
@@ -13,6 +13,7 @@ module ActiveRecord
       # which would cause `[:eager_group_definition, scope_arg1, scope_arg2]` not able to preload together with other `eager_group_definitions`.
       # e.g. `Post.eager_group(:approved_comments_count, [:comments_average_rating_by_author, students[0], true])`
       check_argument_not_blank!(args)
+      check_argument_valid!(args)
 
       spawn.eager_group!(*args)
     end
@@ -37,6 +38,32 @@ module ActiveRecord
     def check_argument_not_blank!(args)
       raise ArgumentError, "The method .eager_group() must contain arguments." if args.blank?
       args.compact_blank!
+    end
+
+    def check_argument_valid!(args)
+      args.each do |eager_group_value|
+        check_eager_group_definitions_exists!(klass, eager_group_value)
+      end
+    end
+
+    def check_eager_group_definitions_exists!(klass, eager_group_value)
+      case eager_group_value
+      when Symbol, String
+        raise ArgumentError, "Unknown eager group definition :#{eager_group_value}" unless klass.eager_group_definitions.has_key?(eager_group_value)
+      when Array
+        definition_name = eager_group_value.first
+        raise ArgumentError, "Unknown eager group definition :#{definition_name}" unless klass.eager_group_definitions.has_key?(definition_name)
+      when Hash
+        eager_group_value.each do |association_name, association_eager_group_values|
+          association_klass = klass.reflect_on_association(association_name).klass
+
+          Array.wrap(association_eager_group_values).each do |association_eager_group_value|
+            check_eager_group_definitions_exists!(association_klass, association_eager_group_value)
+          end
+        end
+      else
+        raise ArgumentError, "Unknown eager_group argument :#{eager_group_value.inspect}"
+      end
     end
   end
 end

--- a/lib/eager_group.rb
+++ b/lib/eager_group.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/module/attribute_accessors'
+require 'active_support/core_ext/class/attribute'
+require 'active_support/core_ext/hash'
 require 'eager_group/version'
 
 module EagerGroup
@@ -9,30 +11,39 @@ module EagerGroup
 
   def self.included(base)
     base.extend ClassMethods
+    base.class_eval do
+      class_attribute :eager_group_definitions, instance_writer: false, default: {}.with_indifferent_access
+    end
   end
 
   module ClassMethods
-    mattr_accessor :eager_group_definitions, default: {}
+    #mattr_accessor :eager_group_definitions, default: {}
+
+    def add_eager_group_definition(ar, definition_name, definition)
+      ar.eager_group_definitions = self.eager_group_definitions.except(definition_name).merge!(definition_name => definition)
+    end
 
     # class Post
     #   define_eager_group :comments_avergage_rating, :comments, :average, :rating
     #   define_eager_group :approved_comments_count, :comments, :count, :*, -> { approved }
     # end
     def define_eager_group(attr, association, aggregate_function, column_name, scope = nil)
-      send :attr_accessor, attr
-      eager_group_definitions[attr] = Definition.new(association, aggregate_function, column_name, scope)
+      add_eager_group_definition(self, attr, Definition.new(association, aggregate_function, column_name, scope))
+      define_definition_accessor(attr)
+    end
 
-      define_method attr,
+    def define_definition_accessor(definition_name)
+      define_method definition_name,
                     lambda { |*args|
-                      query_result_cache = instance_variable_get("@#{attr}")
+                      query_result_cache = instance_variable_get("@#{definition_name}")
                       return query_result_cache if args.blank? && query_result_cache.present?
 
-                      preload_eager_group(attr, *args)
-                      instance_variable_get("@#{attr}")
+                      preload_eager_group(definition_name, *args)
+                      instance_variable_get("@#{definition_name}")
                     }
 
-      define_method "#{attr}=" do |val|
-        instance_variable_set("@#{attr}", val)
+      define_method "#{definition_name}=" do |val|
+        instance_variable_set("@#{definition_name}", val)
       end
     end
   end

--- a/lib/eager_group/preloader.rb
+++ b/lib/eager_group/preloader.rb
@@ -22,10 +22,13 @@ module EagerGroup
 
         if definition_key.is_a?(Hash)
           association_name, definition_key = *definition_key.first
+          next if @records.empty?
+          @klass = @records.first.class.reflect_on_association(association_name).klass
+
           @records = @records.flat_map { |record| record.send(association_name) }
           next if @records.empty?
 
-          @klass = @records.first.class
+
           self.class.new(@klass, @records, Array.wrap(definition_key)).run
         end
 

--- a/lib/eager_group/preloader/aggregation_finder.rb
+++ b/lib/eager_group/preloader/aggregation_finder.rb
@@ -18,7 +18,7 @@ module EagerGroup
       end
 
       def record_ids
-        @record_ids ||= @records.map { |record| record.send(group_by_key) }.uniq
+        @record_ids ||= @records.map { |record| record.send(group_by_key) }
       end
 
       def group_by_key

--- a/lib/eager_group/preloader/aggregation_finder.rb
+++ b/lib/eager_group/preloader/aggregation_finder.rb
@@ -18,7 +18,7 @@ module EagerGroup
       end
 
       def record_ids
-        @record_ids ||= @records.map { |record| record.send(group_by_key) }
+        @record_ids ||= @records.map { |record| record.send(group_by_key) }.uniq
       end
 
       def group_by_key

--- a/spec/integration/eager_group_spec.rb
+++ b/spec/integration/eager_group_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe EagerGroup, type: :model do
           expect{ User.includes(:posts).eager_group(posts: %i[unknown_eager_group_definition]) }.to raise_error(ArgumentError)
         end
 
-        it "should get exception when parent call subclass eager_group_definition" do
+        it "should raise ArgumentError when parent class call a non-exist definition" do
           expect { Vehicle.eager_group(:credited_passengers_count) }.to raise_error(ArgumentError)
         end
       end

--- a/spec/integration/eager_group_spec.rb
+++ b/spec/integration/eager_group_spec.rb
@@ -115,6 +115,42 @@ RSpec.describe EagerGroup, type: :model do
         expect(homeworks[1].student_comments_count).to eq(1)
       end
     end
+
+    context 'support STI' do
+      it 'gets SchoolBus#credited_passengers_count' do
+        buses = SchoolBus.eager_group(:credited_passengers_count, :passengers_count)
+        expect(buses[0].credited_passengers_count).to eq(3)
+        expect(buses[0].passengers_count).to eq(4)
+      end
+
+      it 'gets Sedan#credited_passengers_count' do
+        sedans = Sedan.eager_group(:credited_passengers_count, :passengers_count)
+        expect(sedans[0].credited_passengers_count).to eq(1)
+        expect(sedans[0].passengers_count).to eq(4)
+      end
+
+      it 'gets Vehicle#passengers_count' do
+        vehicles = Vehicle.eager_group(:passengers_count)
+        expect(vehicles[0].passengers_count).to eq(4)
+        expect(vehicles[1].passengers_count).to eq(4)
+      end
+    end
+
+    context 'check arguments' do
+      context 'definition not exists' do
+        it 'should raise ArgumentError' do
+          expect{ Sedan.eager_group(:young_passengers_count) }.to raise_error(ArgumentError)
+        end
+
+        it 'should raise ArgumentError from association' do
+          expect{ User.includes(:posts).eager_group(posts: %i[unknown_eager_group_definition]) }.to raise_error(ArgumentError)
+        end
+
+        it "should get exception when parent call subclass eager_group_definition" do
+          expect { Vehicle.eager_group(:credited_passengers_count) }.to raise_error(ArgumentError)
+        end
+      end
+    end
   end
 
   describe '.preload_eager_group' do

--- a/spec/support/data.rb
+++ b/spec/support/data.rb
@@ -26,3 +26,16 @@ post2.comments.create(status: 'approved', rating: 5, author: teacher1)
 
 homework1 = Homework.create(student: student1, teacher: teacher1)
 homework1 = Homework.create(student: student2, teacher: teacher1)
+
+bus = SchoolBus.create(name: 'elementary bus')
+sedan = Sedan.create(name: 'honda accord')
+
+bus.passengers.create(name: 'Ruby', age: 7)
+bus.passengers.create(name: 'Mike', age: 8)
+bus.passengers.create(name: 'Zach', age: 9)
+bus.passengers.create(name: 'Jacky', age: 10)
+
+sedan.passengers.create(name: 'Ruby', age: 7)
+sedan.passengers.create(name: 'Mike', age: 8)
+sedan.passengers.create(name: 'Zach', age: 9)
+sedan.passengers.create(name: 'Jacky', age: 10)

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -56,4 +56,26 @@ class Homework < ActiveRecord::Base
   define_eager_group :student_comments_count, :comments, :count, '*'
 end
 
+class Vehicle < ActiveRecord::Base
+  has_many :passengers
+  has_many :users, through: :passengers
+
+  define_eager_group :passengers_count, :passengers, :count, '*'
+end
+
+class SchoolBus < Vehicle
+  define_eager_group :credited_passengers_count, :passengers, :count, '*', -> { where('age < 10') }
+  define_eager_group :young_passengers_count, :passengers, :count, '*', -> { where('age < 8') }
+end
+
+class Sedan < Vehicle
+  define_eager_group :credited_passengers_count, :passengers, :count, '*', -> { where('age < 8') }
+
+end
+
+class Passenger < ActiveRecord::Base
+  belongs_to :vehicle
+
+end
+
 ActiveRecord::Base.logger = Logger.new(STDOUT)

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -46,4 +46,18 @@ ActiveRecord::Schema.define do
     t.integer :teacher_id
     t.integer :student_id
   end
+
+  create_table :vehicles, force: true do |t|
+    t.string :type
+    t.string :name
+    t.timestamps null: false
+  end
+
+  create_table :passengers, force: true do |t|
+    t.integer :vehicle_id
+    t.string :name
+    t.integer :age
+
+    t.timestamps null: false
+  end
 end


### PR DESCRIPTION
# Context
A bug was found when active record model using STI, a parent class has multiple subclasses.

```
class A < ApplicationRecord
  has_many :comments
end

class B < A
  define_eager_group :comments_count, :comments, :count, :*
end

class C < A
  define_eager_group :comments_count, :comments, :count, :*, -> { where(status: :approved) }
end
```
In Rails console, you would see
`C.eager_group_definitions.object_id == B.eager_group_definitions.object_id` returns `true`.
And this cause a bug that B.eager_group(:comments_count) actually using C's definition. (depend on the order ruby file is loaded).

This is because gem use `mattr_accessor`, if we use `class_attribute`, it should able to resolve this problem, every class could has its own `eager_group_definitions`.

# Change log
- Refactor with `class_attribute` so that it resolve STI bugs
- Add a validation on `eager_group` method, raising error if argument is wrong
- Improve accessor definition methods
- Add inheritance related unit tests

